### PR TITLE
Add last minute OTIO fixes to release

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -786,14 +786,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/25.04.2/src/kdenlive-25.04.2.tar.xz",
-                    "sha256": "338552fbe675df671e05a5ebce8744e8b1d07db9e36f44e83655eff9ce2d4281",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 8763,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/release-service/$version/src/kdenlive-$version.tar.xz"
+                    "type": "git",
+                    "url": "https://invent.kde.org/multimedia/kdenlive.git",
+                    "commit": "305c03d80d734336d36723aef1c63020be3cacec"
                     }
                 }
             ]


### PR DESCRIPTION
This is to be en par with the binaries (windows, mac, appimage) we are distributing for release